### PR TITLE
Registro usuarios en programas

### DIFF
--- a/src/app/domain/mappers/formularioPrograma.Mapper.ts
+++ b/src/app/domain/mappers/formularioPrograma.Mapper.ts
@@ -1,0 +1,26 @@
+import { FormularioPrograma } from "../models/formulario.models";
+
+export class FormularioProgramaMapper {
+  static fromBackend(data: any): FormularioPrograma {
+    return {
+      idFormulario: data.idFormulario,
+      programaId: data.programaId,
+      nombrePrograma: data.nombrePrograma,
+      colaboradorId: data.colaboradorId,
+      estado: data.estado,
+      campos: data.campos,
+      fechaCreacion: data.fechaCreacion,
+      valoresDiligenciados: data.valoresDiligenciados || []
+    };
+  }
+
+  static toBackend(formulario: FormularioPrograma): any {
+    return {
+      programaId: formulario.programaId,
+      nombrePrograma: formulario.nombrePrograma,
+      colaboradorId: formulario.colaboradorId,
+      campos: formulario.campos,
+      valoresDiligenciados: formulario.valoresDiligenciados || [],
+    };
+  }
+}

--- a/src/app/domain/models/formulario.models.ts
+++ b/src/app/domain/models/formulario.models.ts
@@ -1,0 +1,21 @@
+// models/formulario-programa.model.ts
+export interface CampoFormulario {
+  nombre: string;
+  tipo: string;
+}
+
+export interface ValuesDiligenciados {
+  fechaDiligencia: Date;
+
+}
+
+export interface FormularioPrograma {
+  idFormulario?: string;
+  programaId: string;
+  nombrePrograma: string;
+  colaboradorId: string;
+  estado?: string;
+  campos: CampoFormulario[];
+  fechaCreacion?: string;
+  valoresDiligenciados: ValuesDiligenciados[];
+}

--- a/src/app/domain/repositories/formularioPrograma.repository.ts
+++ b/src/app/domain/repositories/formularioPrograma.repository.ts
@@ -1,0 +1,8 @@
+import { Observable } from "rxjs";
+import { formProgramaRequest, responseFormPrograma } from "../../infrastructure/helpers/interfaces/formPrograma.interface"; 
+export abstract class FormularioProgramaRepository {
+    
+    
+    abstract crearFormulario(idColaborador:string, campos: formProgramaRequest): 
+    Observable<responseFormPrograma>; 
+}

--- a/src/app/infrastructure/dto/formPrograma.dto.ts
+++ b/src/app/infrastructure/dto/formPrograma.dto.ts
@@ -1,0 +1,28 @@
+
+export interface CampoDTO {
+  nombre: string;
+  tipo: string;  // Ej: 'string', 'number', etc.
+}
+
+export interface ValorDiligenciadoDTO {
+  nombreCampo: string;
+  valor: any;  // Puede ser de cualquier tipo (string, number, boolean, etc.)
+}
+
+export interface DiligenciaDTO {
+  fechaDiligencia: string;  // Fecha en formato ISO string
+  valores: ValorDiligenciadoDTO[];
+}
+
+export interface FormularioProgramaDTO {
+  idFormulario: string;  // UUID del formulario
+  programaId: string;  // ID del programa relacionado
+  nombrePrograma: string;  // Nombre del programa relacionado
+  colaboradorId: string;  // ID del colaborador que crea el formulario
+  estado: string;  // Estado del formulario (por defecto "ACTIVO")
+  campos: CampoDTO[];  // Lista de campos dinámicos que se deben diligenciar
+  valoresDiligenciados?: DiligenciaDTO[];  // (Opcional) Múltiples conjuntos de valores diligenciados
+  fechaCreacion: string;  // Fecha de creación en formato ISO string
+  formato: Record<string, any>
+
+}

--- a/src/app/infrastructure/dto/programa.dto.ts
+++ b/src/app/infrastructure/dto/programa.dto.ts
@@ -1,6 +1,9 @@
-
+export interface InformacionDTO{
+    campo: string;
+    valor: string;
+}
 export interface ProgramaDto {
-
+    
     id: string,
     idColaborador: string,
     colaborador: string,
@@ -8,7 +11,12 @@ export interface ProgramaDto {
     nombrePrograma: string,
     fechaCreacion: string,
     idColaboradorResponsable: string,
-    nombreColaboradorResponsable: string,
+    ColaboradorResponsable: string,
+    informacion: InformacionDTO[];
     formato: Record<string, any>
+    nombreColaboradorResponsable: string;
+    idPrograma: string;
+    colaboradorCreador: string;
     
+
 }

--- a/src/app/infrastructure/helpers/interfaces/formPrograma.interface.ts
+++ b/src/app/infrastructure/helpers/interfaces/formPrograma.interface.ts
@@ -1,4 +1,4 @@
-import { FormularioProgramaDTO} from "../../dto/formPrograma.dto"; 
+import { FormularioProgramaDTO} from "../../dto/formPrograma.dto";
 
 export interface formProgramaRequest {
 
@@ -32,6 +32,8 @@ export interface CampoFormulario {
   }
 
   export interface DiligenciarFormularioRequest {
+    idFormulario: string;
+    colaboradorId: string;
     valores: {
       nombreCampo: string;
       valor: any; // Puede ser string, number, etc.

--- a/src/app/infrastructure/helpers/interfaces/formPrograma.interface.ts
+++ b/src/app/infrastructure/helpers/interfaces/formPrograma.interface.ts
@@ -1,0 +1,43 @@
+import { FormularioProgramaDTO} from "../../dto/formPrograma.dto"; 
+
+export interface formProgramaRequest {
+
+   // programaId: string;
+   idPrograma: string;
+    formato: Record<string, any>
+}
+//se esta utilizando para crear formulario y obtener formulario por ID
+export interface responseFormPrograma {
+    formulario: {
+        idFormulario: string;
+        nombrePrograma: string;
+        estado: string;
+        campos: Array<{
+          nombre: string;
+          tipo: string;
+        }>;
+        valoresDiligenciados: Array<{
+          fechaDiligencia: string;
+          valores: Array<{
+            nombreCampo: string;
+            valor: any;
+          }>
+        }>;
+      };
+}
+// Define el tipo de cada campo del formulario
+export interface CampoFormulario {
+    nombre: string;
+    tipo: string;  // 'string', 'number', etc.
+  }
+
+  export interface DiligenciarFormularioRequest {
+    valores: {
+      nombreCampo: string;
+      valor: any; // Puede ser string, number, etc.
+    }[];
+  }
+  export interface ResponseDiligenciarFormulario {
+    message: string;
+    formulario: any;
+  }

--- a/src/app/infrastructure/services/formPrograma/formulario-programa.service.spec.ts
+++ b/src/app/infrastructure/services/formPrograma/formulario-programa.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormularioProgramaService } from './formulario-programa.service';
+
+describe('FormularioProgramaService', () => {
+  let service: FormularioProgramaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FormularioProgramaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/infrastructure/services/formPrograma/formulario-programa.service.ts
+++ b/src/app/infrastructure/services/formPrograma/formulario-programa.service.ts
@@ -14,7 +14,6 @@ export class FormularioProgramaService {
 
   private Url: string = `${environment.apiUrl}/api/formPrograma`;
 
-
   constructor(
   private http: HttpClient) {}
 
@@ -32,8 +31,8 @@ export class FormularioProgramaService {
     }
 
    //Método para obtener el formulario por ID
-   
-   
+
+
    }
    obtenerFormulario(idPrograma: string, idFormulario: string): Observable<responseFormPrograma> {
     return this.http.get<responseFormPrograma>(`${this.Url}/${idPrograma}/formularios/${idFormulario}`)
@@ -56,8 +55,11 @@ obtenerFormularioPorId(idFormulario: string): Observable<any> {
 }
   //Método para diligenciar un formulario
 
-  diligenciarFormulario(idFormulario: string, data: DiligenciarFormularioRequest): Observable<ResponseDiligenciarFormulario>{
-    return this.http.post<ResponseDiligenciarFormulario>(`${this.Url}/formularios/${idFormulario}/diligenciar`, data).pipe(
+  diligenciarFormulario(colaboradorId: string, idFormulario: string, data: DiligenciarFormularioRequest):
+  Observable<ResponseDiligenciarFormulario>{
+
+    console.log(`Formulario ID: ${idFormulario}, Colaborador ID: ${colaboradorId}`);
+  return this.http.post<ResponseDiligenciarFormulario>(`${this.Url}/formularios/${colaboradorId}/${idFormulario}/diligenciar`, data).pipe(
       catchError(error => {
         console.error('Error al diligenciar el formulario', error);
         return throwError(error);

--- a/src/app/infrastructure/services/formPrograma/formulario-programa.service.ts
+++ b/src/app/infrastructure/services/formPrograma/formulario-programa.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@angular/core';
+import { catchError, Observable, throwError } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../enviroments/enviroment';
+import { formProgramaRequest, responseFormPrograma, DiligenciarFormularioRequest, ResponseDiligenciarFormulario} from '../../helpers/interfaces/formPrograma.interface';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FormularioProgramaService {
+
+
+
+  private Url: string = `${environment.apiUrl}/api/formPrograma`;
+
+
+  constructor(
+  private http: HttpClient) {}
+
+  crearFormularioPrograma(colaboradorId: string, datos: formProgramaRequest): Observable<responseFormPrograma> {
+    return this.http.post<responseFormPrograma>(`${this.Url}/${colaboradorId}/formularios/crear/`, datos).pipe(
+      catchError(this.handleError)
+    )
+
+  }
+  private handleError(error: HttpErrorResponse){
+    if (error.status === 400) {
+      return throwError(() => new Error('Este programa ya tiene un formulario asociado.'));
+    } else {
+      return throwError(() => new Error('Ocurrió un error inesperado. Inténtalo de nuevo más tarde.'));
+    }
+
+   //Método para obtener el formulario por ID
+   
+   
+   }
+   obtenerFormulario(idPrograma: string, idFormulario: string): Observable<responseFormPrograma> {
+    return this.http.get<responseFormPrograma>(`${this.Url}/${idPrograma}/formularios/${idFormulario}`)
+    .pipe(
+      catchError(error => {
+        console.error('Error al obtener el formulario:', error);
+        return throwError(error);
+      })
+    );
+  }
+
+  //método para obtener el formulario or ID y poder diligenciar
+obtenerFormularioPorId(idFormulario: string): Observable<any> {
+  return this.http.get<any>(`${this.Url}/formularios/${idFormulario}`).pipe(
+    catchError(error => {
+      console.log('Error al obtener el formulario', error);
+      return throwError(error);
+    })
+  )
+}
+  //Método para diligenciar un formulario
+
+  diligenciarFormulario(idFormulario: string, data: DiligenciarFormularioRequest): Observable<ResponseDiligenciarFormulario>{
+    return this.http.post<ResponseDiligenciarFormulario>(`${this.Url}/formularios/${idFormulario}/diligenciar`, data).pipe(
+      catchError(error => {
+        console.error('Error al diligenciar el formulario', error);
+        return throwError(error);
+      })
+    )
+  }
+}

--- a/src/app/presentation/formatos-de-registros/formatos-de-registros-routing.module.ts
+++ b/src/app/presentation/formatos-de-registros/formatos-de-registros-routing.module.ts
@@ -1,14 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { DialogAsignarNombre, FormatoRegistroProgramaComponent } from '../modules/formulacion/formato-registro-programa/formato-registro-programa.component';
 
 const routes: Routes = [
 
 
-  {
-    path: 'formato-registro-programa', 
-    component: FormatoRegistroProgramaComponent
-  },
 
   
   

--- a/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.css
+++ b/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.css
@@ -1,0 +1,112 @@
+/* Contenedor del formulario */
+.form-container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #f2f2f2;
+    border-radius: 8px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  }
+  
+  /* Título del formulario */
+  h2 {
+    text-align: center;
+    color: #11224D; /* Color corporativo */
+    font-size: 24px;
+    margin-bottom: 20px;
+  }
+  
+  /* Agrupación de campos */
+  .form-group {
+    margin-bottom: 20px;
+  }
+  
+  /* Etiquetas */
+  label {
+    display: block;
+    margin-bottom: 8px;
+    color: #193A6F; /* Color corporativo */
+    font-weight: bold;
+  }
+  
+  /* Inputs de texto y número */
+  input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #193A6F; /* Color corporativo */
+    border-radius: 4px;
+    font-size: 16px;
+    color: #333;
+    transition: border-color 0.3s ease;
+    background-color: #fff;
+  }
+  
+  input:focus {
+    border-color: #F98125; /* Color corporativo */
+    outline: none;
+  }
+  
+  /* Mensajes de error */
+  .error-message {
+    color: #F98125; /* Color corporativo */
+    font-size: 14px;
+    margin-top: 5px;
+  }
+  
+  /* Botón de envío */
+  button.btn {
+    width: 100%;
+    padding: 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    color: #fff;
+    background-color: #193A6F; /* Color corporativo */
+    transition: background-color 0.3s ease;
+  }
+  
+  button.btn:hover {
+    background-color: #F98125; /* Hover color */
+  }
+  
+  button.btn:disabled {
+    background-color: #FB9B50; /* Botón deshabilitado */
+    cursor: not-allowed;
+  }
+  
+  /* Estilos responsivos */
+  @media (max-width: 768px) {
+    .form-container {
+      padding: 15px;
+    }
+  
+    input {
+      font-size: 14px;
+    }
+  
+    button.btn {
+      padding: 10px;
+      font-size: 14px;
+    }
+  }
+  
+  @media (max-width: 480px) {
+    .form-container {
+      padding: 10px;
+    }
+  
+    h2 {
+      font-size: 20px;
+    }
+  
+    input {
+      font-size: 14px;
+    }
+  
+    button.btn {
+      padding: 10px;
+      font-size: 14px;
+    }
+  }
+  

--- a/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.html
+++ b/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.html
@@ -1,0 +1,38 @@
+<div class="form-container">
+    <h2>Diligenciar Formulario</h2>
+  
+    <form [formGroup]="formularioForm" (ngSubmit)="diligenciarFormulario()">
+      <div *ngFor="let campo of camposFormulario" class="form-group">
+        <label [for]="campo.nombre">{{ campo.nombre }}</label>
+        <input
+          *ngIf="campo.tipo === 'string'"
+          [id]="campo.nombre"
+          [formControlName]="campo.nombre"
+          type="text"
+          class="form-control"
+          placeholder="Ingrese {{ campo.nombre }}"
+          required
+        />
+        
+        <input
+          *ngIf="campo.tipo === 'number'"
+          [id]="campo.nombre"
+          [formControlName]="campo.nombre"
+          type="number"
+          class="form-control"
+          placeholder="Ingrese {{ campo.nombre }}"
+          required
+        />
+  
+        <div *ngIf="formularioForm.get(campo.nombre)?.invalid && formularioForm.get(campo.nombre)?.touched" class="error-message">
+          <span *ngIf="formularioForm.get(campo.nombre)?.errors?.['required']">{{ campo.nombre }} es requerido.</span>
+        </div>
+      </div>
+      
+      <!-- Botón de envío que llama al método diligenciarFormulario -->
+      <button type="submit" class="btn btn-primary" [disabled]="formularioForm.invalid">
+        Diligenciar Formulario
+      </button>
+    </form>
+  </div>
+  

--- a/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.html
+++ b/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.html
@@ -1,6 +1,7 @@
 <div class="form-container">
     <h2>Diligenciar Formulario</h2>
-  
+
+
     <form [formGroup]="formularioForm" (ngSubmit)="diligenciarFormulario()">
       <div *ngFor="let campo of camposFormulario" class="form-group">
         <label [for]="campo.nombre">{{ campo.nombre }}</label>
@@ -13,7 +14,7 @@
           placeholder="Ingrese {{ campo.nombre }}"
           required
         />
-        
+
         <input
           *ngIf="campo.tipo === 'number'"
           [id]="campo.nombre"
@@ -23,16 +24,18 @@
           placeholder="Ingrese {{ campo.nombre }}"
           required
         />
-  
+
         <div *ngIf="formularioForm.get(campo.nombre)?.invalid && formularioForm.get(campo.nombre)?.touched" class="error-message">
           <span *ngIf="formularioForm.get(campo.nombre)?.errors?.['required']">{{ campo.nombre }} es requerido.</span>
         </div>
       </div>
-      
+
       <!-- Botón de envío que llama al método diligenciarFormulario -->
       <button type="submit" class="btn btn-primary" [disabled]="formularioForm.invalid">
         Diligenciar Formulario
       </button>
+      <div *ngIf="formularioForm.invalid">
+        <p class="error">Por favor complete todos los campos obligatorios.</p>
+      </div>
     </form>
   </div>
-  

--- a/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.spec.ts
+++ b/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegistroParticipantesComponent } from './registro-participantes.component';
+
+describe('RegistroParticipantesComponent', () => {
+  let component: RegistroParticipantesComponent;
+  let fixture: ComponentFixture<RegistroParticipantesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegistroParticipantesComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegistroParticipantesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.ts
+++ b/src/app/presentation/modules/ejecucion-programas/RegistroParticipantes/registro-participantes/registro-participantes.component.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { FormularioProgramaService } from '../../../../../infrastructure/services/formPrograma/formulario-programa.service';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MaterialModule } from '../../../material/material/material.module';
+import { DiligenciarFormularioRequest} from '../../../../../infrastructure/helpers/interfaces/formPrograma.interface';
+import Swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-registro-participantes',
+  standalone: true,
+  imports: [
+    MaterialModule
+  ],
+  templateUrl: './registro-participantes.component.html',
+  styleUrl: './registro-participantes.component.css'
+})
+export class RegistroParticipantesComponent implements OnInit{
+  formularioForm!: FormGroup;
+  camposFormulario: any[] = [];
+  idFormulario: string = 'cce24ebe-9769-4477-9254-2b8f3ec43a82';
+
+  constructor(
+    private fb: FormBuilder,
+    private formularioService: FormularioProgramaService
+  ) { }
+
+  ngOnInit(): void {
+    //SE OBTIENE EL FORMULARIO Y SUS CAMPOS DESDE EL BACKEND
+    this.formularioService.obtenerFormularioPorId(this.idFormulario).subscribe(
+      response => {
+        this.camposFormulario = response.campos;
+        this.initializeForm();
+      },
+    error => {
+      console.error('Error al obtener el formulario', error);
+    }
+      
+    );
+  }
+
+initializeForm(): void {
+  const formGroupConfig: any = {};
+  this.camposFormulario.forEach(campo => {
+    formGroupConfig[campo.nombre] = [ '', campo.tipo === 'string' ? Validators.required : Validators.required];
+  });
+
+  this.formularioForm = this.fb.group(formGroupConfig);
+}
+
+
+  diligenciarFormulario(): void {
+    if (this.formularioForm.invalid) {
+      return;
+    }
+
+    const valores: DiligenciarFormularioRequest = {
+      valores: this.camposFormulario.map(campo => ({
+        nombreCampo: campo.nombre,
+        valor: this.formularioForm.get(campo.nombre)?.value
+      }))
+    };
+
+    //const idFormulario = 'a28f59c3-9ca8-4ec9-826c-74ef533bc556'; // Reemplaza esto con el ID real del formulario
+    this.formularioService.diligenciarFormulario(this.idFormulario, valores).subscribe(
+      response => {
+        console.log('Formulario diligenciado correctamente:', response);
+        // Aquí puedes mostrar un mensaje de éxito o redirigir al usuario
+
+         // Mostrar el mensaje de éxito usando SweetAlert
+         Swal.fire({
+          title: '¡Formulario creado!',
+          text: 'El formulario ha sido diligenciado correctamente.',
+          icon: 'success',
+          confirmButtonText: 'Aceptar'
+        });
+        this.formularioForm.reset();
+
+      },
+      error => {
+        console.error('Error al diligenciar el formulario:', error);
+
+        Swal.fire({
+          title: 'Error',
+          text: 'Hubo un error al diligenciar el formulario. Intenta nuevamente.',
+          icon: 'error',
+          confirmButtonText: 'Aceptar'
+        });
+      }
+    );
+  }
+  }
+

--- a/src/app/presentation/modules/ejecucion-programas/ejecucion-programas-routing.module.ts
+++ b/src/app/presentation/modules/ejecucion-programas/ejecucion-programas-routing.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { FormRegistroParticipantesComponent } from './form-registro-participantes/form-registro-participantes.component';
+import { RegistroParticipantesComponent } from './RegistroParticipantes/registro-participantes/registro-participantes.component';
+import { VerParticipantesInscritosPorProgramaComponent } from './formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component';
+
+const routes: Routes = [
+
+  {
+    path: 'formulario-registro',
+    component: FormRegistroParticipantesComponent
+  },
+  {
+    path: 'registro-participantes',
+    component: RegistroParticipantesComponent
+  },
+  {
+    path: 'programa/:idPrograma/formulario/:idFormulario',
+    component: VerParticipantesInscritosPorProgramaComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class EjecucionProgramasRoutingModule { }

--- a/src/app/presentation/modules/ejecucion-programas/ejecucion-programas.module.ts
+++ b/src/app/presentation/modules/ejecucion-programas/ejecucion-programas.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { EjecucionProgramasRoutingModule } from './ejecucion-programas-routing.module';
+import { MaterialModule } from '../material/material/material.module';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+
+
+  declarations: [],
+  imports: [
+    CommonModule,
+    EjecucionProgramasRoutingModule,
+    MaterialModule,
+     FormsModule
+  ],
+ 
+})
+export class EjecucionProgramasModule { }

--- a/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.css
+++ b/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.css
@@ -1,0 +1,91 @@
+/* Estilos generales */
+form {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #f2f2f2;
+    border-radius: 8px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  }
+  
+  label {
+    color: #11224D;
+    font-weight: bold;
+    display: block;
+    margin-bottom: 5px;
+  }
+  
+  input {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 15px;
+    border: 1px solid #193A6F;
+    border-radius: 4px;
+    font-size: 16px;
+    color: #333;
+    background-color: #fff;
+    transition: border-color 0.3s ease;
+  }
+  
+  input:focus {
+    border-color: #F98125;
+    outline: none;
+  }
+  
+  button {
+    padding: 10px 20px;
+    margin-top: 10px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    color: #fff;
+    background-color: #193A6F;
+    transition: background-color 0.3s ease;
+  }
+  
+  button:hover {
+    background-color: #F98125;
+  }
+  
+  button[type="submit"] {
+    background-color: #F98125;
+  }
+  
+  button[type="submit"]:hover {
+    background-color: #FB9B50;
+  }
+
+  
+  /* Diseño responsive para pantallas grandes y pequeñas */
+  @media (max-width: 768px) {
+    form {
+      padding: 15px;
+    }
+  
+    input {
+      font-size: 14px;
+    }
+  
+    button {
+      width: 100%;
+      margin-top: 10px;
+    }
+  }
+  
+  @media (max-width: 480px) {
+    form {
+      padding: 10px;
+    }
+  
+    input {
+      font-size: 12px;
+    }
+  
+    button {
+      width: 100%;
+      padding: 8px 15px;
+      font-size: 14px;
+    }
+  }
+  

--- a/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.html
+++ b/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.html
@@ -1,0 +1,46 @@
+<form [formGroup]="formularioProgramaForm" (ngSubmit)="onSubmit()">
+
+
+  
+  <!-- <div>
+    <label for="programa">Programa</label>
+    <select id="programa" formControlName="idPrograma">
+     <label for="programa">Selecciona un programa</label> -->
+    <!-- <option value="" disabled selected>Selecciona un programa</option>
+      <option *ngFor="let programa of programas" [value]="programa.idPrograma">
+ {{ programa.nombrePrograma}}
+      </option>
+      </select>
+  </div>  -->
+
+
+
+  <div>
+    <label for="nombrePrograma">nombre del Programa</label>
+    <input id="nombrePrograma" placeHolder="nombre del programa" matInput formControlName="nombrePrograma"/>
+  </div>
+
+  <div formArrayName="campos">
+    <div *ngFor="let campo of campos.controls; let i = index" [formGroupName]="i">
+      <mat-form-field appearance="outline">
+      <label>Nombre del Campo</label>
+      <input matInput id="nombre" formControlName="nombre" placeHolder="nombre del campo"/>
+      <mat-error *ngIf="campo.get('nombre')?.invalid">Campo obligatorio</mat-error>
+      </mat-form-field>
+
+  <mat-form-field appearance="outline">
+      <label for="tipo">Tipo de dato</label>
+      <input matInput id="tipo" formControlName="tipo" placeHolder="tipo de dato/text/number/fecha"/>
+      <mat-error *ngIf="campo.get('tipo')?.invalid">Campo obligatorio</mat-error>
+    </mat-form-field>
+
+      <button type="button" (click)="eliminarCampo(i)">Eliminar Campo</button>
+    </div>
+  </div>
+
+  <button type="button" (click)="agregarCampo()">Agregar Campo</button>
+  <button type="submit" [disabled]="formularioProgramaForm.invalid || isSubmitting">
+    {{ isSubmitting ? 'Enviando...' : 'Crear Formulario' }}
+  </button>
+
+</form>

--- a/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.spec.ts
+++ b/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormRegistroParticipantesComponent } from './form-registro-participantes.component';
+
+describe('FormRegistroParticipantesComponent', () => {
+  let component: FormRegistroParticipantesComponent;
+  let fixture: ComponentFixture<FormRegistroParticipantesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormRegistroParticipantesComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FormRegistroParticipantesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.ts
+++ b/src/app/presentation/modules/ejecucion-programas/form-registro-participantes/form-registro-participantes.component.ts
@@ -1,0 +1,151 @@
+import { Component, OnInit } from '@angular/core';
+import { ProgramaService } from '../../../../infrastructure/services/programa/programa.service';
+import { Programa } from '../../../../domain/models/programa.models';
+
+import { MaterialModule } from '../../material/material/material.module';
+import { FormsModule } from '@angular/forms';
+import { FormBuilder, FormArray, FormGroup, Validators } from '@angular/forms';
+import { FormularioProgramaService } from '../../../../infrastructure/services/formPrograma/formulario-programa.service';
+import { AuthenticacionService } from '../../../../infrastructure/services/authenticacion/authenticacion.service';
+import Swal from 'sweetalert2';
+import { MatSnackBar } from '@angular/material/snack-bar';
+@Component({
+  selector: 'app-form-registro-participantes',
+  standalone: true,
+  imports: [
+    MaterialModule,
+    FormsModule
+  ],
+  templateUrl: './form-registro-participantes.component.html',
+  styleUrl: './form-registro-participantes.component.css'
+})
+export class FormRegistroParticipantesComponent implements OnInit {
+
+
+  //código para listar los prgramas
+  //variable que almacena los programas activos
+  programas: Programa[]=[];
+
+
+  //selectedProgramaId: string = '';
+  selectedProgramaNombre: string = ''; //seleccionar por nombre de programa
+  page: number = 1;
+  limit: number = 10;
+  isSubmitting = false;
+
+  //Formulario reactivo
+  formularioProgramaForm: FormGroup;
+
+  constructor( private programaService: ProgramaService,
+               private fb: FormBuilder,
+               private formProgramaService: FormularioProgramaService,
+               private authService: AuthenticacionService,
+               private snackBar: MatSnackBar
+  ) {
+
+    this.formularioProgramaForm = this.fb.group({
+      nombrePrograma: ['',  Validators.required],
+      campos: this.fb.array([])
+    });
+  }
+  
+
+  ngOnInit(): void {
+   
+// this.ObtenerProgramasActivos() //cargar programas activos
+  
+  }
+
+  // ObtenerProgramasActivos(): void {
+  //   this.programaService.obtenerProgramas(this.page, this.limit).subscribe({
+  //     next: (response)=> {
+  //       //filtrar programas activos
+  //       this.programas = response.programas.filter((programa)=> programa.estado === 'ACTIVO');
+  //       console.log(this.programas); 
+  //     },
+  //   error: (error)=> {
+  //     console.error('Error al obtener los programas', error);
+  //   }
+  //   });
+  // }
+  
+  
+ 
+ get campos():FormArray{
+  return this.formularioProgramaForm.get('campos') as FormArray;
+ }
+
+ //Agregar nuevo campo
+ agregarCampo(){
+  try {
+    const campoForm = this.fb.group({
+      nombre: ['', Validators.required],
+      tipo: ['', Validators.required]
+    });
+    this.campos.push(campoForm);
+    console.log(this.campos); // Verifica si los campos se están agregando
+    
+  //verifica el estado del Array, para revisar errores que puedan ocurrir con los controles del formulario
+    console.log(this.formularioProgramaForm.get('campos'));
+  
+  } catch (error) {
+    console.error('Error al agregar un campo:', error);
+  }
+ }
+
+ //ELIMINAR CAMPO
+ eliminarCampo(index: number){
+  this.campos.removeAt(index);
+ }
+onSubmit(): void{
+  console.log(this.formularioProgramaForm.value); 
+    const colaboradorId = this.authService.getColaboradorId();
+  
+    if (!colaboradorId) {
+
+      //muestra mensaje visual para el usuario en caso se no encontrar el id del colaborador.
+      this.snackBar.open('ID del colaborador no encontrado. Por favor, inicia sesión nuevamente.', 'Cerrar', {
+        duration: 3000,
+        panelClass: ['error-snackbar']
+      });
+      return;
+    }
+
+    if (this.formularioProgramaForm.invalid || this.campos.length === 0) {
+      this.snackBar.open('El formulario es inválido o o no tiene campos. Revisa los campos', 'Cerrar', {
+        duration: 3000,
+        panelClass: ['error-snackbar']
+      });
+      return;
+    }
+    this.isSubmitting = true;
+
+    console.log(this.formularioProgramaForm.value); // Para ver el valor enviado
+
+    this.formProgramaService.crearFormularioPrograma(colaboradorId, this.formularioProgramaForm.value).subscribe(response => {
+      this.isSubmitting = false;
+      //Mensaje de éxito
+Swal.fire({
+  title: 'Exito',
+  text:'El formulario para el programa ha sido creado exitosameente',
+  icon: 'success',
+  confirmButtonText: 'Aceptar'
+});
+
+  },
+  error => {
+    this.isSubmitting = false;
+    this.snackBar.open(error.message, 'Cerrar',{
+      duration: 3000,
+      panelClass: ['error-snackbar']
+    })
+    
+  }
+
+);
+}
+
+
+
+ }
+

--- a/src/app/presentation/modules/ejecucion-programas/formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component.html
+++ b/src/app/presentation/modules/ejecucion-programas/formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component.html
@@ -1,0 +1,30 @@
+<div *ngIf="formulario">
+    <h1>Formulario: {{ formulario.nombrePrograma }}</h1>
+    <p>Estado: {{ formulario.estado }}</p>
+    <h3>Campos:</h3>
+    <ul>
+      <li *ngFor="let campo of formulario.campos">
+        {{ campo.nombre }} ({{ campo.tipo }})
+      </li>
+    </ul>
+    <h3>Valores diligenciados:</h3>
+    <ul>
+      <li *ngFor="let diligencia of formulario.valoresDiligenciados">
+        Fecha: {{ diligencia.fechaDiligencia }}
+        <ul>
+          <li *ngFor="let valor of diligencia.valores">
+            {{ valor.nombreCampo }}: {{ valor.valor }}
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  
+  <!-- Mostrar un mensaje de error si ocurre -->
+  <div *ngIf="errorMessage">
+    <p class="error-message">{{ errorMessage }}</p>
+  </div>
+  
+  <div *ngIf="!formulario && !errorMessage">
+    <p>Cargando formulario...</p>
+  </div>

--- a/src/app/presentation/modules/ejecucion-programas/formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component.spec.ts
+++ b/src/app/presentation/modules/ejecucion-programas/formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VerParticipantesInscritosPorProgramaComponent } from './ver-participantes-inscritos-por-programa.component';
+
+describe('VerParticipantesInscritosPorProgramaComponent', () => {
+  let component: VerParticipantesInscritosPorProgramaComponent;
+  let fixture: ComponentFixture<VerParticipantesInscritosPorProgramaComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VerParticipantesInscritosPorProgramaComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VerParticipantesInscritosPorProgramaComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/presentation/modules/ejecucion-programas/formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component.ts
+++ b/src/app/presentation/modules/ejecucion-programas/formDiligenciados/ver-participantes-inscritos-por-programa/ver-participantes-inscritos-por-programa.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit } from '@angular/core';
+import { MaterialModule } from '../../../material/material/material.module';
+import { responseFormPrograma } from '../../../../../infrastructure/helpers/interfaces/formPrograma.interface';
+import { ActivatedRoute } from '@angular/router';
+import { FormularioProgramaService } from '../../../../../infrastructure/services/formPrograma/formulario-programa.service';
+@Component({
+  selector: 'app-ver-participantes-inscritos-por-programa',
+  standalone: true,
+  imports: [
+    MaterialModule
+  ],
+  templateUrl: './ver-participantes-inscritos-por-programa.component.html',
+  styleUrl: './ver-participantes-inscritos-por-programa.component.css'
+})
+export class VerParticipantesInscritosPorProgramaComponent implements OnInit{
+
+  formulario!: responseFormPrograma['formulario'];  // Tipo de la respuesta
+  errorMessage: string | null = null; // Para mostrar el error si ocurre
+
+  constructor(
+    private route: ActivatedRoute,
+    private formularioService: FormularioProgramaService
+  ) { }
+
+  ngOnInit(): void {
+    const idPrograma = this.route.snapshot.paramMap.get('idPrograma');
+    const idFormulario = this.route.snapshot.paramMap.get('idFormulario');
+
+    if (idPrograma && idFormulario) {
+      this.formularioService.obtenerFormulario(idPrograma, idFormulario).subscribe(
+        (data: responseFormPrograma) => {
+          this.formulario = data.formulario;
+        },
+        (error) => {
+          this.errorMessage = 'Error al obtener el formulario. Intente de nuevo más tarde.';
+          console.error('Error en el componente al obtener el formulario:', error);
+        }
+      );
+    }
+  }
+
+}


### PR DESCRIPTION
Breve resumen de los cambios o funcionalidades implementadas.
Contexto sobre por qué se realizaron estos cambios.
Cualquier instrucción o nota adicional para los revisores.
Se implementa una primera parte del flujo de trabajo del bpm Registro de de participantes, la cual incluye que el colaborador con rol de directora cdc, pueda crear un formulario asociado a un programa para que el colaborador con rol lider de programa pueda visualizar y diligenciar el formulario guardando la información del usuario según los campos del formulario. 

- se valida que un programa tenga un único formulario. 
- se valida que no se ingresen datos duplicados para mantener la consistencia de datos de los usuarios duplicados. 
pendiente: la implementación de mensajes de correo electrónico y seleccionar formularios. 

notas: implementación del modelo DTO para el formulario, Mapper y Repositorys para el formulario programa
//se elimina el componente formulario Registro de programa que no se utilizo.

**Historias de usuarios asociadas:** 
21Crear formulario dinámico para registro de usuarios en programas
22Asignar formulario a  un programa
15Diligenciar campos para inscribir participante

